### PR TITLE
Fix permission error for entry script

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,5 +25,6 @@ RUN pip install bokeh
 COPY prepare.sh /usr/bin/prepare.sh
 
 RUN mkdir /opt/app
+RUN ["chmod", "+x", "/usr/bin/prepare.sh"]
 
 ENTRYPOINT ["tini", "-g", "--", "/usr/bin/prepare.sh"]


### PR DESCRIPTION
When running `docker-compose up scheduler` I was getting the error:

```text
scheduler_1  | [FATAL tini (7)] exec /usr/bin/prepare.sh failed: Permission denied
```

Changing the permissions within the image now allows the image to run and I can view the dask dashboard.

Note: I am new to docker, so please let me know if there is a better way to address my issue above.