### PR TITLE
MRG: Add image with jupyter

### DIFF
--- a/.github/workflows/ReleaseLatest.yml
+++ b/.github/workflows/ReleaseLatest.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Push base image to github
         run: docker push ghcr.io/mne-tools/mne-python:latest
 
+      - name: Build jupyter image
+        run: docker-compose build jupyter
+
+      - name: Rename jupyter image tag for release
+        run: docker tag mnetools/mne-python-jupyter ghcr.io/mne-tools/mne-python-jupyter
+
+      - name: Push jupyter image to github
+        run: docker push ghcr.io/mne-tools/mne-python-jupyter:latest
+
       - name: Build plot image
         run: docker-compose build plot
 

--- a/.github/workflows/ReleaseTags.yml
+++ b/.github/workflows/ReleaseTags.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Push base image to github
         run: docker push ghcr.io/mne-tools/mne-python:${{ env.RELEASE_VERSION }}
 
+      - name: Build jupyter image
+        run: docker-compose build jupyter
+
+      - name: Rename jupyter image tag for release
+        run: docker tag mnetools/mne-python-jupyter ghcr.io/mne-tools/mne-python-jupyter:${{ env.RELEASE_VERSION }}
+
+      - name: Push jupyter image to github
+        run: docker push ghcr.io/mne-tools/mne-python-jupyter:${{ env.RELEASE_VERSION }}
+
       - name: Build plot image
         run: docker-compose build plot
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker run mnetools/mne-python-jupyter ipython -c "import mne; mne.sys_info()"
 
       - name: Run jupyter test
-        run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python-jupyter ipython /opt/app/examples/tests/plot.py
+        run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python-jupyter ipython /opt/app/examples/tests/base.py
 
       # Plot
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Base
+
       - name: Build base image
         run: docker-compose build base
     
@@ -35,6 +37,19 @@ jobs:
 
       - name: Run base test
         run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python python /opt/app/examples/tests/base.py
+
+      # Jupyter
+
+      - name: Build plot image
+        run: docker-compose build jupyter
+
+      - name: System info - plot image
+        run: docker run mnetools/mne-python-jupyter ipython -c "import mne; mne.sys_info()"
+
+      - name: Run plotting test
+        run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python-plot ipython /opt/app/examples/tests/plot.py
+
+      # Plot
 
       - name: Build plot image
         run: docker-compose build plot

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,14 @@ jobs:
 
       # Jupyter
 
-      - name: Build plot image
+      - name: Build jupyter image
         run: docker-compose build jupyter
 
-      - name: System info - plot image
+      - name: System info - jupyter image
         run: docker run mnetools/mne-python-jupyter ipython -c "import mne; mne.sys_info()"
 
-      - name: Run plotting test
-        run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python-plot ipython /opt/app/examples/tests/plot.py
+      - name: Run jupyter test
+        run: docker run -v `pwd`:/opt/app/examples mnetools/mne-python-jupyter ipython /opt/app/examples/tests/plot.py
 
       # Plot
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository also hosts the code and runs the github actions to build and rel
 To download a notebook capable MNE docker image and launch a jupyter lab session run:
 
 ```bash
-docker run -p 8888:8888 ghcr.io/mne-tools/mne-python
+docker run -p 8888:8888 ghcr.io/mne-tools/mne-python-jupyter jupyter lab --ip="*"
 ```
 
 ## Available Docker images
@@ -17,7 +17,8 @@ docker run -p 8888:8888 ghcr.io/mne-tools/mne-python
 The repository contains several images:
 
 1. `mne-tools/mne-python`: contains a minimal MNE-Python installation that can run python scripts. It does not contain 3D plotting capabilities or a notebook server
-2. `mne-tools/mne-python-plot`: adds 2D and 3D plotting capabilities to the base image.
+2. `mne-tools/mne-python-jupyter`: adds jupyter lab to the base image.
+3. `mne-tools/mne-python-plot`: adds 2D and 3D plotting capabilities to the `mne-python-jupyter` image.
 
 Several versions of the image are stored that correspond to different MNE-Python versions.
 Images are also build with from the main branch of MNE-Python, these contain _dev_ in the name.

--- a/base/Dockerfile.jupyter
+++ b/base/Dockerfile.jupyter
@@ -1,6 +1,6 @@
 FROM mnetools/mne-python
 
-RUN pip install jupyterlab
+RUN pip install jupyterlab ipywidgets ipyvtklink
 
 EXPOSE 8888
 

--- a/base/Dockerfile.jupyter
+++ b/base/Dockerfile.jupyter
@@ -2,4 +2,6 @@ FROM mnetools/mne-python
 
 RUN pip install jupyterlab
 
+EXPOSE 8888
+
 ENTRYPOINT ["tini", "-g", "--", "/usr/bin/prepare.sh"]

--- a/base/Dockerfile.jupyter
+++ b/base/Dockerfile.jupyter
@@ -1,0 +1,5 @@
+FROM mnetools/mne-python
+
+RUN pip install jupyterlab
+
+ENTRYPOINT ["tini", "-g", "--", "/usr/bin/prepare.sh"]

--- a/base/Dockerfile.plot
+++ b/base/Dockerfile.plot
@@ -1,4 +1,4 @@
-FROM mnetools/mne-python
+FROM mnetools/mne-python-jupyter
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,17 @@ services:
       dockerfile: Dockerfile
     image: mnetools/mne-python
 
-  plot:
+  jupyter:
     depends_on:
         - base
+    build:
+      context: ./base
+      dockerfile: Dockerfile.jupyter
+    image: mnetools/mne-python-jupyter
+
+  plot:
+    depends_on:
+        - jupyter
     build:
       context: ./base
       dockerfile: Dockerfile.plot


### PR DESCRIPTION
This adds a new docker image called `mne-python-jupyter`. This image will be pushed to the GitHub container registry as `mne-tools/mne-python-jupyter `

The image is built on top of the base image, and adds Jupyter lab support.

I chose to build on top of the base image rather than the plot image as this image will only be 1.1 GB, whereas the 2/3D plotting enabled images is 2+GB.

I have also modified the plotting image to build on top of the new jupyter image rather than base. This adds only 0.2GB to the image size, but gives significant usability improvements. To summarise:

* base: 0.94 GB
* base+jupyter: 1.1 GB
* base+jupyter+plot: 2.3 GB
* base+plot: 2.1 GB (based on previous PR)

I have added tests to ensure the new image indeed builds with ipython.