### PR TITLE
Add workflow_dispatch option to release latest CI

### DIFF
--- a/.github/workflows/ReleaseLatest.yml
+++ b/.github/workflows/ReleaseLatest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
This CI script packages the latest code from the main branch of MNE-Python in to a docker image. This PR adds the ability to manually trigger a new run of this CI script. This is useful when code improvements are made in MNE-Python repo and you want them to be made available in this docker package.