### PR TITLE
Remove s option from conda clean

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -48,7 +48,7 @@ RUN conda install --yes \
     numpy==1.21.0 \
     pandas==1.3.0 \
     tini==0.18.0 \
-    && conda clean -tipsy \
+    && conda clean -tipy \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -45,7 +45,7 @@ RUN conda install --yes \
     dask-labextension==3.0.0 \
     python-graphviz \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension@3.0.0 \
-    && conda clean -tipsy \
+    && conda clean -tipy \
     && jupyter lab clean \
     && jlpm cache clean \
     && npm cache clean --force \


### PR DESCRIPTION
The 's' option in `conda clean` is no longer available. This is causing the generation of notebooks to fail (see recent actions).

https://docs.conda.io/projects/conda/en/latest/commands/clean.html